### PR TITLE
[MINOR] Remove parametrization of train_size to prevent failure (temporary)

### DIFF
--- a/xaiographs/exgraph/explainer/explainer.py
+++ b/xaiographs/exgraph/explainer/explainer.py
@@ -59,7 +59,6 @@ class Explainer(object):
                                                                              sample_ids_mask_2_explain=sample_ids_mask,
                                                                              feature_cols=features_info.feature_columns,
                                                                              target_cols=target_info.target_columns,
-                                                                             train_size=0.8,
                                                                              train_stratify=True)
 
         top1_importance_features, global_explainability, global_nodes_importance, df_explanation_sample = (


### PR DESCRIPTION
ImportanceCalculator has been parametrized so that `train_size` parameter equals 0.8.
This is currently causing the flow to break during coalition worth calculation, while providing a solution, the parameter won't be used

# Test
Please explain how this patch was tested.
- Tested locally
