### PR TITLE
[FEATURE] Printer with verbosity flag

### DIFF
--- a/xaiographs/common/utils.py
+++ b/xaiographs/common/utils.py
@@ -155,7 +155,7 @@ def sample_by_target(ids: np.ndarray, top1_targets: np.ndarray, num_samples: int
     return sample_ids_mask, sample_ids
 
 
-def xgprint(verbose: int = False, *args, **kwargs) -> None:
+def xgprint(verbose: int = 0, *args, **kwargs) -> None:
     """
     Wrapper for the builtin `print` function
 

--- a/xaiographs/why/why.py
+++ b/xaiographs/why/why.py
@@ -23,7 +23,7 @@ class Why(object):
     def __init__(self, language: str, local_expl: pd.DataFrame, local_nodes: pd.DataFrame, why_elements: pd.DataFrame,
                  why_target: pd.DataFrame, why_templates: pd.DataFrame, reliability: pd.DataFrame,
                  n_local_features: int = 2, n_global_features: int = 2, min_reliability: float = 0.0,
-                 verbose: int = False):
+                 verbose: int = 0):
         """
         Constructor method for Why
 


### PR DESCRIPTION
# Description
Issue: https://jira.tid.es/browse/RECOPROD-176

* Wrapper for the builtin print function (_xgprint_) with a new argument _verbose_:
  * _verbose > 0_ -> print
  * _verbose <= 0_ -> do not print
* Verbosity level in class _Why_ as an example

In advance, the rule for stdout messages should be:
* Add new argument _verbose_ in the constructor of the main classes; _xgprint_ calls should look like this:
> xgprint(self.verbose, "Message")
* Use builtin _print_ for important messages (critical messages, errors and warnings): always printed.
* Use _xgprint_ for the rest of messages: printed depending on the verbosity flag.
* Take verbosity flag into account for _tqdm_ loops:
> for i in tqdm(range(10), disable=not self.verbose):

# Test
- Tested locally
