### PR TITLE
Read all CSVs mandatory to xaioweb & not port required in params

### DIFF
--- a/xaiographs/viz/launcher.py
+++ b/xaiographs/viz/launcher.py
@@ -1,4 +1,3 @@
-
 from xaiographs.common.constants import WEB_ENTRY_POINT
 
 import argparse
@@ -43,10 +42,12 @@ CSV_FILES = ["global_explainability.csv",
              "local_graph_nodes.csv",
              "local_graph_edges.csv",
              "data_correlation_matrix_dataset.csv",
-             "[DEPRECATED]_input_dataset.csv",
-             "[DEPRECATED]_input_dataset_discretized.csv",
-             "[DEPRECATED]_global_target_explainability.csv",
-             "[DEPRECATED]_local_explainability.csv",
+             "fairness_confusion_matrix.csv",
+             "fairness_highest_correlation.csv",
+             "fairness_independence.csv",
+             "fairness_separation.csv",
+             "fairness_sufficiency.csv",
+             "fairness_sumarize_criterias.csv"
              ]
 
 
@@ -280,8 +281,8 @@ def main():
     """
     # Handle input arguments
     parser = argparse.ArgumentParser(description='XAIoGraphs')
-    parser.add_argument('-p', '--port', default=8080, help='Web server port', type=int, required=True)
     parser.add_argument('-d', '--data', default=None, help='CSV files path', type=str, required=True)
+    parser.add_argument('-p', '--port', default=8080, help='Web server port', type=int, required=False)
     parser.add_argument('-f', '--force', action='store_true',
                         help='Force building the web from scratch, overwriting the existing one', required=False)
     parser.add_argument('-o', '--open', action='store_true', help='Open web in browser', required=False)


### PR DESCRIPTION
# Description
Issue: https://jira.tid.es/browse/RECOPROD-180

* Añadidos en el chequeo de ficheros los CSVs de la pestaña de fairness
* Eliminados los CSVs deprecados
* Cambiado el required=false del parámetro que indica el puerto. Por defecto se usa el puerto 8080

# Test
- Tested locally: Probado haciendo una instalación de la librería en mi local y lanzado con el comando:

```
>> xaioweb -d C:\Users\rmg\Documents\workspace\XAIoGraphs\examples\example_data_viz  -o
```

* Salida del chequeo

```
Apparently the web is already deployed
╔══════════════════════════════════════════════════╦════════════════════╗
║ NPM Installed                                    ║ v18.10.0           ║
╚══════════════════════════════════════════════════╩════════════════════╝
╔══════════════════════════════════════════════════╦════════════════════╗
║ Backend node package                             ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ Frontend node package                            ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ XAIoWeb distribution                             ║ AVAILABLE          ║
╚══════════════════════════════════════════════════╩════════════════════╝
╔══════════════════════════════════════════════════╦════════════════════╗
║ global_explainability.csv                        ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ global_target_distribution.csv                   ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ global_graph_description.csv                     ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ global_graph_nodes.csv                           ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ global_graph_edges.csv                           ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ local_dataset_reliability.csv                    ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ local_reason_why.csv                             ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ local_graph_nodes.csv                            ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ local_graph_edges.csv                            ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ data_correlation_matrix_dataset.csv              ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ fairness_confusion_matrix.csv                    ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ fairness_highest_correlation.csv                 ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ fairness_independence.csv                        ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ fairness_separation.csv                          ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ fairness_sufficiency.csv                         ║ AVAILABLE          ║
╠══════════════════════════════════════════════════╬════════════════════╣
║ fairness_sumarize_criterias.csv                  ║ AVAILABLE          ║
╚══════════════════════════════════════════════════╩════════════════════╝
```
