### PR TITLE
[fixed] Library web deploy

### DIFF
--- a/xaiographs/viz/frontpiled/index.html
+++ b/xaiographs/viz/frontpiled/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><html lang="en"><head><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
     <meta charset="utf-8">
     <title>XAioGraphs</title>
-    <base href="frontpiled/">
+    <base href="/.xaioweb/">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
# Description
Issue: https://jira.tid.es/browse/RECOPROD-214

Revisar el código de publicación de la web para que pueda ser lanzada correctamente desde el endpoint creado durante la instalación de la librería como paquete

# Test
- Tested locally

Pasos a seguir:
1.- Comprobamos que no está el paquete instalado en nuestro virutalenv (para ello hacemos un pip list)

2.- Desde la carpeta raiz del proyecto creamos e instalamos la librerría (para ello usamos python setup.py install).
Esto puede demorar un poco hasta que finalmente nos informa que ha sido satisfactoriamente instalada

3.- Podemos comprobar que está disponible repitiendo el paso 1 (volvemos ha hacer pip list)

4.- Levantamos la web usando el endpoint creado. Para ello usaremos el comando xaioweb -o -d [ruta_a_los_jsons]
<img width="666" alt="Captura de pantalla 2023-02-10 a las 14 38 48" src="https://user-images.githubusercontent.com/79313163/218980754-c66a8368-5695-42b8-aa6c-6220e23b978f.png">
Tras unos segundos (la primera vez debe realizar la copia de los archivos que necesita) se abrirá automáticamente el navegador con la web desplegada
