### PR TITLE
[fixed] Web deploy on Library

### DIFF
--- a/xaiographs/viz/frontpiled/index.html
+++ b/xaiographs/viz/frontpiled/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html><html lang="en"><head><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="">
     <meta charset="utf-8">
     <title>XAioGraphs</title>
-    <base href="frontpiled/">
+    <base href="/.xaioweb/">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/xaiographs/viz/launcher.py
+++ b/xaiographs/viz/launcher.py
@@ -1,3 +1,5 @@
+from xaiographs.common.constants import WEB_ENTRY_POINT
+
 import argparse
 import http.server
 import os
@@ -10,14 +12,17 @@ from copy import deepcopy
 
 MY_PROTOCOL = 'http://'
 MY_HOST_NAME = 'localhost'
-MY_HTML_FOLDER_PATH = 'frontpiled/'
+MY_HTML_FOLDER_PATH = 'frontpiled'
 MY_HOME_PAGE_FILE_PATH = 'index.html'
 COL_HEIGHT_LEFT = 50
 COL_HEIGHT_RIGHT = 20
-JSON_PUBLIC_FOLDER = os.path.join(MY_HTML_FOLDER_PATH, 'assets/public')
 TEXT_COLOR_WHITE = '\033[0m'
 TEXT_COLOR_RED = '\033[91m'
 TEXT_COLOR_GREEN = '\033[92m'
+XAIOWEB_DISTRIBUTION = 'XAIoWeb distribution'
+HIDDEN_DIR = '.{}'.format(WEB_ENTRY_POINT)
+SRC_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), MY_HTML_FOLDER_PATH)
+JSON_PUBLIC_FOLDER = os.path.join(HIDDEN_DIR, 'assets/public')
 
 JSON_FILES = ["global_explainability.json",
              "global_target_distribution.json",
@@ -40,7 +45,7 @@ JSON_FILES = ["global_explainability.json",
 class MyHttpRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path == '/':
-            self.path = os.path.join(MY_HTML_FOLDER_PATH, MY_HOME_PAGE_FILE_PATH)
+            self.path = os.path.join(HIDDEN_DIR, MY_HOME_PAGE_FILE_PATH)
         return http.server.SimpleHTTPRequestHandler.do_GET(self)
 
 
@@ -102,6 +107,28 @@ def print_bottom_line():
         print(u"\u2550", end='')
     print(u"\u255D")
 
+def check_deploy_web(force: bool = False) -> None:
+    """
+    This function check build of the frontend.
+    In case of build folder doesn't exist, execute a build process.
+    :return: Boolean value to continue with the publishing process.
+    """
+    print_upper_line()
+
+    if not os.path.exists(os.path.join(os.getcwd(),HIDDEN_DIR)):
+        print_message_line(XAIOWEB_DISTRIBUTION, 'MISSING', TEXT_COLOR_WHITE)
+        print_message_line(XAIOWEB_DISTRIBUTION, 'INSTALLING...', TEXT_COLOR_WHITE)
+        shutil.copytree(SRC_DIR, HIDDEN_DIR)
+    else:
+        if(force):
+            print_message_line(XAIOWEB_DISTRIBUTION, 'UPDATING...', TEXT_COLOR_WHITE)
+            if os.path.exists(HIDDEN_DIR):
+                shutil.rmtree(HIDDEN_DIR)
+            shutil.copytree(SRC_DIR, HIDDEN_DIR)
+    
+    print_message_line(XAIOWEB_DISTRIBUTION, 'AVAILABLE', TEXT_COLOR_GREEN)
+    print_bottom_line()
+
 
 def clean_json_public_folder():
     """
@@ -146,8 +173,11 @@ def main():
     parser.add_argument('-d', '--data', default=None, help='JSON files path', type=str, required=False)
     parser.add_argument('-p', '--port', default=8080, help='Web server port', type=int, required=False)
     parser.add_argument('-o', '--open', action='store_true', help='Open web in browser', required=False)
+    parser.add_argument('-f', '--force', action='store_true',
+                        help='Force building the web from scratch, overwriting the existing one', required=False)
     args = deepcopy(parser.parse_args().__dict__)
 
+    check_deploy_web(force=args.get('force'))
     process_json_files(path=args.get('data'))
 
     my_handler = MyHttpRequestHandler


### PR DESCRIPTION
# Description
Issue: https://jira.tid.es/browse/RECOPROD-214

Modificar el archivo de publicación de la web (launcher) para que funcione utilizando el endpoint disponible en Xaiograph como paquete

# Test
- Tested locally

1.- pip list -> comprobamos que en nuestro virtualenv no está ya instalado el paquete de Xaio, en caso de estarlo necesitaríamos realizar un pip uninstall

2.- python setup.py install -> con esto creamos el paquete a partir del código fuente y lo añadimos a nuestro virtualenv como una librería más

3.- xaioweb -o -d [ruta_a_los_jsons] -> procedemos a levantar la web (si es la primera vez tardará unos segundos porque necesita compiar los archivos necesarios para su publicación)
![image](https://user-images.githubusercontent.com/79313163/219023254-db79ad1d-1eb7-46ff-8110-9f6c7bc8f57a.png)

