### PR TITLE
[fixed] Feature_value importance legend

### DIFF
--- a/xaiographs/viz/frontend/src/app/components/global/details/features_target.component.html
+++ b/xaiographs/viz/frontend/src/app/components/global/details/features_target.component.html
@@ -10,6 +10,22 @@
         </div>
         <google-chart class="globalFeatureTargetChart" #chart [type]="type" [data]="dataGraph" [columns]="columnNames" [options]="options" *ngIf="displayGraph && showFrecuency"> </google-chart>
         <google-chart class="globalFeatureTargetChart" #chart [type]="type" [data]="dataGraphNoFrec" [columns]="columnNamesNoFrec" [options]="optionsNoFrec" *ngIf="displayGraph && !showFrecuency"> </google-chart>
+        <div fxFlex fxLayout="row" fxLayoutAlign="center center"  *ngIf="displayGraph">
+            <div fxFlex fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="center center" style="padding-top: 15px;">
+                <div fxLayout="row" fxLayoutGap="5px">
+                    <div style="width: 15px; height: 15px; border: 1px solid black; border-radius: 3px;" [style.background-color]="colorTheme.positiveValue"></div>
+                    <label>Positive values</label>
+                </div>
+                <div fxLayout="row" fxLayoutGap="5px">
+                    <div style="width: 15px; height: 15px; border: 1px solid black; border-radius: 3px;" [style.background-color]="colorTheme.negativeValue"></div>
+                    <label>Negative values</label>
+                </div>
+                <div fxLayout="row" fxLayoutGap="5px" *ngIf="showFrecuency">
+                    <div style="width: 15px; height: 15px; border: 1px solid black; border-radius: 3px;" [style.background-color]="colorTheme.frecuencyValue"></div>
+                    <label>Frecuency</label>
+                </div>
+            </div>
+        </div>
         <img src="../../../../assets/empty.png" class="globalNoData" *ngIf="!displayGraph" alt="No data" />
     </div>
 </div>

--- a/xaiographs/viz/frontend/src/app/components/global/details/graph.component.html
+++ b/xaiographs/viz/frontend/src/app/components/global/details/graph.component.html
@@ -4,4 +4,16 @@
         <label class="globalNetGraphSubTitle">target selected: {{ currentTarget }}</label>
     </div>
     <div id="divGraph" class="globalNetGraphChart"></div>
+    <div fxFlex fxLayout="row" fxLayoutAlign="center center">
+        <div fxFlex fxLayout="row" fxLayoutGap="15px" fxLayoutAlign="center center">
+            <div fxLayout="row" fxLayoutGap="5px">
+                <div style="width: 15px; height: 15px; border: 1px solid black; border-radius: 3px;" [style.background-color]="colorTheme.positiveValue"></div>
+                <label>Positive values</label>
+            </div>
+            <div fxLayout="row" fxLayoutGap="5px">
+                <div style="width: 15px; height: 15px; border: 1px solid black; border-radius: 3px;" [style.background-color]="colorTheme.negativeValue"></div>
+                <label>Negative values</label>
+            </div>
+        </div>
+    </div>
 </div>

--- a/xaiographs/viz/frontend/src/app/components/global/details/heatmap.component.html
+++ b/xaiographs/viz/frontend/src/app/components/global/details/heatmap.component.html
@@ -31,7 +31,7 @@
                 </div>
             </div>
         </div>
-        <div fxFlex="3" fxLayout="column" style="border: 1px solid black" [style.background-image]="heatMapLegendStyle" fxLayoutAlign="space-between center">
+        <div fxFlex="3" fxLayout="column" style="border: 1px solid black; color: white" [style.background-image]="heatMapLegendStyle" fxLayoutAlign="space-between center">
             <label>+</label>
             <label>-</label>
         </div>


### PR DESCRIPTION
# Description
Issue: https://jira.tid.es/browse/RECOPROD-257

Cambiar el orden de presentación de los valores del heatmap para que las features aparezcan en el mismo orden en el que aparecen en la Feature Importance, en orden descendiente de importancia, con el objetivo de facilitar su lectura y comprensión.


Del mismo modo, se ordenarán los valores desglosados de cada una de las features (elementos en horizontal) para que vallan del más positivo (color rojo) al más negativo (color azul)

# Test
- Tested locally
