### PR TITLE
[refactor] Explainer: remove dataset as a constructor parameter, move it to fit method

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ df_titanic, feature_cols, target_cols, y_true, y_predict = load_titanic_discreti
 df_global_semantics, df_target_semantics, df_why_templates = load_titanic_why(language=LANG)
 
 # EXPLAINER
-explainer = Explainer(dataset=df_titanic, importance_engine='LIDE', verbose=1)
-explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+explainer = Explainer(importance_engine='LIDE', verbose=1)
+explainer.fit(df=df_titanic, feature_cols=feature_cols, target_cols=target_cols)
 
 # WHY
 why = Why(language=LANG,

--- a/docs/source/examples/examples.md
+++ b/docs/source/examples/examples.md
@@ -87,8 +87,8 @@ handing it a list containing the names of the feature columns (`feature_cols`) a
 of the target columns (`target_cols`), it will execute all of the computations required to provide the explainability:
 
 ```python
->>> explainer = Explainer(dataset=df_dataset, importance_engine='LIDE', verbose=1)
->>> explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+>>> explainer = Explainer(importance_engine='LIDE', verbose=1)
+>>> explainer.fit(df=df_dataset, feature_cols=feature_cols, target_cols=target_cols)
 ```
 &nbsp;
 

--- a/docs/source/quickstart/quickstart.md
+++ b/docs/source/quickstart/quickstart.md
@@ -43,8 +43,8 @@ df_titanic, feature_cols, target_cols, y_true, y_predict = load_titanic_discreti
 df_global_semantics, df_target_semantics, df_why_templates = load_titanic_why(language=LANG)
 
 # EXPLAINER
-explainer = Explainer(dataset=df_titanic, importance_engine='LIDE', verbose=1)
-explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+explainer = Explainer(importance_engine='LIDE', verbose=1)
+explainer.fit(df=df_titanic, feature_cols=feature_cols, target_cols=target_cols)
 
 # WHY
 why = Why(language=LANG,

--- a/examples/body_performance_example.py
+++ b/examples/body_performance_example.py
@@ -16,8 +16,8 @@ You should have received a copy of the Affero GNU General Public License along w
 see https://www.gnu.org/licenses/."""
 
 from xaiographs import Explainer
-from xaiographs import Why
 from xaiographs import Fairness
+from xaiographs import Why
 from xaiographs.datasets import load_body_performance_discretized, load_body_performance_why
 
 LANG = 'en'
@@ -27,24 +27,23 @@ example_dataset, feature_cols, target_cols, y_true, y_predict = load_body_perfor
 df_global_semantics, df_target_semantics, df_why_templates = load_body_performance_why(language=LANG)
 
 # EXPLAINER
-explainer = Explainer(dataset=example_dataset, importance_engine='LIDE', number_of_features=11, verbose=1)
-explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+explainer = Explainer(importance_engine='LIDE', number_of_features=11, verbose=1)
+explainer.fit(df=example_dataset, feature_cols=feature_cols, target_cols=target_cols)
 
 # WHY
 why = Why(language=LANG,
-            local_reliability=explainer.local_dataset_reliability,
-            local_feat_val_expl=explainer.local_feature_value_explainability,
-            why_elements=df_global_semantics,
-            why_templates=df_why_templates,
-            why_target=df_target_semantics,
-            sample_ids_to_export=explainer.sample_ids_to_display,
-            verbose=1)
+          local_reliability=explainer.local_dataset_reliability,
+          local_feat_val_expl=explainer.local_feature_value_explainability,
+          why_elements=df_global_semantics,
+          why_templates=df_why_templates,
+          why_target=df_target_semantics,
+          sample_ids_to_export=explainer.sample_ids_to_display,
+          verbose=1)
 why.fit()
 
 # FAIRNESS
 f = Fairness(verbose=1)
 f.fit(df=example_dataset[feature_cols + [y_true] + [y_predict]],
-        sensitive_cols=['gender', 'age'],
-        target_col=y_true,
-        predict_col=y_predict)
-
+      sensitive_cols=['gender', 'age'],
+      target_col=y_true,
+      predict_col=y_predict)

--- a/examples/education_performance_example.py
+++ b/examples/education_performance_example.py
@@ -16,8 +16,8 @@ You should have received a copy of the Affero GNU General Public License along w
 see https://www.gnu.org/licenses/."""
 
 from xaiographs import Explainer
-from xaiographs import Why
 from xaiographs import Fairness
+from xaiographs import Why
 from xaiographs.datasets import load_education_performance_discretized, load_education_performance_why
 
 LANG = 'en'
@@ -27,23 +27,23 @@ example_dataset, feature_cols, target_cols, y_true, y_predict = load_education_p
 df_global_semantics, df_target_semantics, df_why_templates = load_education_performance_why(language=LANG)
 
 # EXPLAINER
-explainer = Explainer(dataset=example_dataset, importance_engine='LIDE', number_of_features=13, verbose=1)
-explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+explainer = Explainer(importance_engine='LIDE', number_of_features=13, verbose=1)
+explainer.fit(df=example_dataset, feature_cols=feature_cols, target_cols=target_cols)
 
 # WHY
 why = Why(language=LANG,
-            local_reliability=explainer.local_dataset_reliability,
-            local_feat_val_expl=explainer.local_feature_value_explainability,
-            why_elements=df_global_semantics,
-            why_templates=df_why_templates,
-            why_target=df_target_semantics,
-            sample_ids_to_export=explainer.sample_ids_to_display,
-            verbose=1)
+          local_reliability=explainer.local_dataset_reliability,
+          local_feat_val_expl=explainer.local_feature_value_explainability,
+          why_elements=df_global_semantics,
+          why_templates=df_why_templates,
+          why_target=df_target_semantics,
+          sample_ids_to_export=explainer.sample_ids_to_display,
+          verbose=1)
 why.fit()
 
 # FAIRNESS
 f = Fairness(verbose=1)
 f.fit(df=example_dataset[feature_cols + [y_true] + [y_predict]],
-        sensitive_cols=['age', 'sex', 'total_salary', 'accomodation', 'parental_status'],
-        target_col=y_true,
-        predict_col=y_predict)
+      sensitive_cols=['age', 'sex', 'total_salary', 'accomodation', 'parental_status'],
+      target_col=y_true,
+      predict_col=y_predict)

--- a/examples/titanic_example.py
+++ b/examples/titanic_example.py
@@ -16,8 +16,8 @@ You should have received a copy of the Affero GNU General Public License along w
 see https://www.gnu.org/licenses/."""
 
 from xaiographs import Explainer
-from xaiographs import Why
 from xaiographs import Fairness
+from xaiographs import Why
 from xaiographs.datasets import load_titanic_discretized, load_titanic_why
 
 LANG = 'en'
@@ -27,18 +27,18 @@ example_dataset, feature_cols, target_cols, y_true, y_predict = load_titanic_dis
 df_global_semantics, df_target_semantics, df_why_templates = load_titanic_why(language=LANG)
 
 # EXPLAINER
-explainer = Explainer(dataset=example_dataset, importance_engine='LIDE', verbose=1)
-explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+explainer = Explainer(importance_engine='LIDE', verbose=1)
+explainer.fit(df=example_dataset, feature_cols=feature_cols, target_cols=target_cols)
 
 # WHY
 why = Why(language=LANG,
-            local_reliability=explainer.local_dataset_reliability,
-            local_feat_val_expl=explainer.local_feature_value_explainability,
-            why_elements=df_global_semantics,
-            why_templates=df_why_templates,
-            why_target=df_target_semantics,
-            sample_ids_to_export=explainer.sample_ids_to_display,
-            verbose=1)
+          local_reliability=explainer.local_dataset_reliability,
+          local_feat_val_expl=explainer.local_feature_value_explainability,
+          why_elements=df_global_semantics,
+          why_templates=df_why_templates,
+          why_target=df_target_semantics,
+          sample_ids_to_export=explainer.sample_ids_to_display,
+          verbose=1)
 why.fit()
 
 # FAIRNESS

--- a/xaiographs/examples/body_performance_example.py
+++ b/xaiographs/examples/body_performance_example.py
@@ -30,8 +30,8 @@ def main():
     df_global_semantics, df_target_semantics, df_why_templates = load_body_performance_why(language=LANG)
 
     # EXPLAINER
-    explainer = Explainer(dataset=example_dataset, importance_engine='LIDE', verbose=1)
-    explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+    explainer = Explainer(importance_engine='LIDE', verbose=1)
+    explainer.fit(df=example_dataset, feature_cols=feature_cols, target_cols=target_cols)
 
     # WHY
     why = Why(language=LANG,

--- a/xaiographs/examples/education_performance_example.py
+++ b/xaiographs/examples/education_performance_example.py
@@ -30,8 +30,8 @@ def main():
     df_global_semantics, df_target_semantics, df_why_templates = load_education_performance_why(language=LANG)
 
     # EXPLAINER
-    explainer = Explainer(dataset=example_dataset, importance_engine='LIDE', number_of_features=13, verbose=1)
-    explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+    explainer = Explainer(importance_engine='LIDE', number_of_features=13, verbose=1)
+    explainer.fit(df=example_dataset, feature_cols=feature_cols, target_cols=target_cols)
 
     # WHY
     why = Why(language=LANG,

--- a/xaiographs/examples/titanic_example.py
+++ b/xaiographs/examples/titanic_example.py
@@ -30,8 +30,8 @@ def main():
     df_global_semantics, df_target_semantics, df_why_templates = load_titanic_why(language=LANG)
 
     # EXPLAINER
-    explainer = Explainer(dataset=df_titanic, importance_engine='LIDE', verbose=1)
-    explainer.fit(feature_cols=feature_cols, target_cols=target_cols)
+    explainer = Explainer(importance_engine='LIDE', verbose=1)
+    explainer.fit(df=df_titanic, feature_cols=feature_cols, target_cols=target_cols)
 
     # WHY
     why = Why(language=LANG,

--- a/xaiographs/why.py
+++ b/xaiographs/why.py
@@ -114,7 +114,7 @@ class Why(object):
     def __init__(self, language: str, local_reliability: pd.DataFrame, local_feat_val_expl: pd.DataFrame,
                  why_elements: pd.DataFrame, why_target: pd.DataFrame, why_templates: pd.DataFrame,
                  n_local_features: int = 2, n_global_features: int = 2, min_reliability: float = 0.0,
-                 destination_path: str = './xaioweb_files', sample_ids_to_export: Optional[List[int]] = None,
+                 destination_path: str = './xaioweb_files', sample_ids_to_export: Optional[pd.Series] = None,
                  verbose: int = 0):
         self.__df_why = None
         self.__language = language


### PR DESCRIPTION
# Description

Cambios:
* Se quita el parámetro `dataset` del constructor de la clase `Explainer` y  se reemplaza por el parámetro `df` del método `fit()` de la misma clase
* Se ajusta el tipo del parámetro `sample_ids_to_export` del `Why` ya que requiere un `pandas.Series` pero el tipiado indicaba un `List[int]`

# Test
Please explain how this patch was tested.
- Tested locally
